### PR TITLE
Bump role version to 1.1.0 for Ansible Galaxy

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,21 @@
+---
+namespace: click0
+name: mfsbsd_install_via_linux_lite
+version: 1.1.0
+description: Installing MfsBSD for its subsequent boot and server reboot.
+authors:
+  - Vladislav V. Prodan <github.com/click0>
+license:
+  - BSD-2-Clause
+repository: https://github.com/click0/ansible-mfsbsd-install-via-linux-lite
+documentation: https://github.com/click0/ansible-mfsbsd-install-via-linux-lite/blob/main/README.md
+issues: https://github.com/click0/ansible-mfsbsd-install-via-linux-lite/issues
+tags:
+  - mfsbsd
+  - install
+  - debian
+  - ubuntu
+  - system
+  - rescue
+  - grub
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,9 +5,9 @@ galaxy_info:
   author: Vladislav V. Prodan
   description: Installing MfsBSD for its subsequent boot and server reboot.
   company: https://support.od.ua
-  github_branch: master
+  github_branch: main
   license: BSD
-  min_ansible_version: '2.11'
+  min_ansible_version: '2.16'
   platforms:
     - name: 'Ubuntu'
       versions: ['all']


### PR DESCRIPTION
- Create galaxy.yml with version 1.1.0
- Fix github_branch: master -> main in meta/main.yml
- Bump min_ansible_version from 2.11 to 2.16 (include_tasks required)

https://claude.ai/code/session_01Nwcgd4fukZL9xbuyqButXD