### PR TITLE
files/install_mfsbsd_iso.sh: bump v1.27 -> v1.28 (sync with source repo)

### DIFF
--- a/files/install_mfsbsd_iso.sh
+++ b/files/install_mfsbsd_iso.sh
@@ -7,7 +7,7 @@
 
 script_type="self-contained"
 # shellcheck disable=SC2034
-version_script="1.27"
+version_script="1.28"
 
 set -e
 


### PR DESCRIPTION
## Summary
- Bumps `files/install_mfsbsd_iso.sh` from v1.27 to v1.28 to sync with `FreeBSD-install-scripts` repo.
- Both repos now ship byte-identical scripts (same blob SHA).
- Version bump only — no behavioral changes vs v1.27.

## Test plan
- [ ] `grep version_script= files/install_mfsbsd_iso.sh` → `version_script="1.28"`
- [ ] Run playbook end-to-end against a Linux Lite host, verify uploaded script reports v1.28
- [ ] BIOS path still works (regression check)

https://claude.ai/code/session_01X9o1d2irpniMbHspvB7Rcd

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9o1d2irpniMbHspvB7Rcd)_